### PR TITLE
Switched serde::export::Formatter to std::fmt::Formatter

### DIFF
--- a/couch_rs/Cargo.toml
+++ b/couch_rs/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-serde = { version = "^1.0.116", features = ["derive"] }
+serde = { version = "^1.0.119", features = ["derive"] }
 serde_json = "^1.0.57"
 couch_rs_derive = { version = "0.8.24", optional = true, path = "../couch_rs_derive" }
 url = "^2.1.1"

--- a/couch_rs/src/types/find.rs
+++ b/couch_rs/src/types/find.rs
@@ -1,9 +1,9 @@
 use crate::document::TypedCouchDocument;
-use serde::export::Formatter;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fmt::Display;
+use std::fmt::Formatter;
 
 /// Sort direction abstraction
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Clone)]


### PR DESCRIPTION
`src/types/find.rs` uses `serde::export` instead of `std::fmt` path. The latest serde version (1.0.119) have renamed the module, so that it shouldn't be used 