### PR TITLE
Borrow documents instead of consuming them

### DIFF
--- a/couch_rs/examples/basic_operations/main.rs
+++ b/couch_rs/examples/basic_operations/main.rs
@@ -58,21 +58,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!("--- Creating ---");
 
     // let's add some docs
-    match db.bulk_docs(test_docs(100)).await {
+    match db.bulk_docs(&mut test_docs(100)).await {
         Ok(resp) => {
             println!("Bulk docs completed");
 
             for r in resp {
                 match r {
-                    Ok(details) => println!(
-                        "Id: {}",
-                        details
-                            .as_object()
-                            .unwrap()
-                            .get("_id")
-                            .map(|v| v.as_str().unwrap().to_owned())
-                            .unwrap_or_else(|| "--".to_string())
-                    ),
+                    Ok(details) => println!("Id: {}", details.id),
                     Err(err) => println!("Error: {:?}", err),
                 }
             }

--- a/couch_rs/examples/basic_operations/main.rs
+++ b/couch_rs/examples/basic_operations/main.rs
@@ -70,7 +70,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 }
             }
         }
-        Err(err) => println!("Oops: unable to create documents {}: {:?}", test_docs, err),
+        Err(err) => println!("Oops: unable to create documents {:?}: {:?}", test_docs, err),
     }
 
     println!("--- Finding ---");

--- a/couch_rs/examples/basic_operations/main.rs
+++ b/couch_rs/examples/basic_operations/main.rs
@@ -64,7 +64,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
             for r in resp {
                 match r {
-                    Ok(details) => println!("Id: {}", details.id.unwrap_or_else(|| "--".to_string())),
+                    Ok(details) => println!(
+                        "Id: {}",
+                        details
+                            .as_object()
+                            .unwrap()
+                            .get("_id")
+                            .map(|v| v.as_str().unwrap().to_owned())
+                            .unwrap_or_else(|| "--".to_string())
+                    ),
                     Err(err) => println!("Error: {:?}", err),
                 }
             }

--- a/couch_rs/examples/basic_operations/main.rs
+++ b/couch_rs/examples/basic_operations/main.rs
@@ -58,7 +58,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!("--- Creating ---");
 
     // let's add some docs
-    match db.bulk_docs(&mut test_docs(100)).await {
+    let mut test_docs = test_docs(100);
+    match db.bulk_docs(&mut test_docs).await {
         Ok(resp) => {
             println!("Bulk docs completed");
 
@@ -69,7 +70,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 }
             }
         }
-        Err(err) => println!("Oops: {:?}", err),
+        Err(err) => println!("Oops: unable to create documents {}: {:?}", test_docs, err),
     }
 
     println!("--- Finding ---");

--- a/couch_rs/examples/typed_documents/main.rs
+++ b/couch_rs/examples/typed_documents/main.rs
@@ -49,9 +49,10 @@ async fn main() {
         Err(e) => {
             match e.status {
                 StatusCode::NOT_FOUND => {
+                    let mut doc = serde_json::to_value(td).unwrap();
                     // create the document
-                    match db.create(serde_json::to_value(td).unwrap()).await {
-                        Ok(r) => println!("Document was created with ID: {} and Rev: {}", r.get_id(), r.get_rev()),
+                    match db.create(&mut doc).await {
+                        Ok(r) => println!("Document was created with ID: {} and Rev: {}", r.id, r.rev),
                         Err(err) => println!("Oops: {:?}", err),
                     }
                 }

--- a/couch_rs/examples/typed_documents/main.rs
+++ b/couch_rs/examples/typed_documents/main.rs
@@ -53,7 +53,7 @@ async fn main() {
                     // create the document
                     match db.create(&mut doc).await {
                         Ok(r) => println!("Document was created with ID: {} and Rev: {}", r.id, r.rev),
-                        Err(err) => println!("Oops: {:?}", err),
+                        Err(err) => println!("error creating document {}: {:?}", doc, err),
                     }
                 }
                 _ => {

--- a/couch_rs/examples/typed_views/main.rs
+++ b/couch_rs/examples/typed_views/main.rs
@@ -10,14 +10,14 @@ async fn main() -> CouchResult<()> {
     let client = couch_rs::Client::new_local_test()?;
     let db = client.db(TEST_DB).await?;
 
-    let doc = json!({
+    let mut doc = json!({
         "_id": "jdoe",
         "first_name": "John",
         "last_name": "Doe",
         "funny": true
     });
 
-    db.create(doc).await?;
+    db.create(&mut doc).await?;
 
     let couch_func = CouchFunc {
         map: "function (doc) { if (doc.funny == true) { emit(doc._id, doc.funny); } }".to_string(),

--- a/couch_rs/src/client.rs
+++ b/couch_rs/src/client.rs
@@ -36,6 +36,7 @@ pub(crate) async fn is_accepted(request: RequestBuilder) -> bool {
 }
 
 pub(crate) async fn is_ok(request: RequestBuilder) -> bool {
+    dbg!(&request);
     if let Ok(res) = request.send().await {
         matches!(res.status(), StatusCode::OK | StatusCode::NOT_MODIFIED)
     } else {

--- a/couch_rs/src/client.rs
+++ b/couch_rs/src/client.rs
@@ -36,7 +36,6 @@ pub(crate) async fn is_accepted(request: RequestBuilder) -> bool {
 }
 
 pub(crate) async fn is_ok(request: RequestBuilder) -> bool {
-    dbg!(&request);
     if let Ok(res) = request.send().await {
         matches!(res.status(), StatusCode::OK | StatusCode::NOT_MODIFIED)
     } else {

--- a/couch_rs/src/database.rs
+++ b/couch_rs/src/database.rs
@@ -3,7 +3,7 @@ use crate::client::{is_accepted, is_ok};
 use crate::document::{DocumentCollection, TypedCouchDocument};
 use crate::error::{CouchError, CouchResult};
 use crate::types::design::DesignCreated;
-use crate::types::document::{DocumentCreatedResponse, DocumentCreatedResult, DocumentId};
+use crate::types::document::{DocumentCreatedResponse, DocumentId};
 use crate::types::find::{FindQuery, FindResult};
 use crate::types::index::{DatabaseIndexList, IndexFields};
 use crate::types::query::{QueriesCollection, QueriesParams, QueryParams};

--- a/couch_rs/src/database.rs
+++ b/couch_rs/src/database.rs
@@ -231,7 +231,7 @@ impl Database {
     pub async fn bulk_docs<T: TypedCouchDocument>(
         &self,
         raw_docs: &mut [T],
-    ) -> CouchResult<Vec<CouchResult<DocumentCreatedDetails>>> {
+    ) -> CouchResult<Vec<DocumentCreatedResult>> {
         let body = format!(r#"{{"docs":{} }}"#, to_string(raw_docs)?);
         dbg!(&body);
         let response = self
@@ -712,7 +712,7 @@ impl Database {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn create<T: TypedCouchDocument>(&self, doc: &mut T) -> CouchResult<DocumentCreatedDetails> {
+    pub async fn create<T: TypedCouchDocument>(&self, doc: &mut T) -> DocumentCreatedResult {
         let response = self._client.post(self.name.clone(), to_string(&doc)?).send().await?;
 
         let status = response.status();

--- a/couch_rs/src/lib.rs
+++ b/couch_rs/src/lib.rs
@@ -332,7 +332,7 @@ mod couch_rs_tests {
             let mut docs = docs.into_iter();
             let first_result = docs.next().unwrap();
             assert!(first_result.is_ok());
-            assert!(first_result.unwrap().rev.is_some());
+            assert!(first_result.unwrap().as_object().unwrap().get("_rev").is_some());
 
             let second_result = docs.next().unwrap();
             assert!(second_result.is_err());
@@ -714,8 +714,10 @@ mod couch_rs_tests {
             .unwrap();
 
             // executing 'all' view querying with a specific key should result in 1 and 0 entries, respectively
-            let mut one_key = QueryParams::default();
-            one_key.key = Some(doc.get_id().into_owned());
+            let one_key = QueryParams {
+                key: Some(doc.get_id().into_owned()),
+                ..Default::default()
+            };
 
             assert_eq!(
                 db.query_raw(view_name, view_name, Some(one_key.clone()))
@@ -832,10 +834,14 @@ mod couch_rs_tests {
             let (client, db, docs) = setup_multiple(dbname, 4).await;
             let doc = docs.get(0).unwrap();
 
-            let mut params1 = QueryParams::default();
-            params1.key = Some(doc.get_id().into_owned());
-            let mut params2 = QueryParams::default();
-            params2.include_docs = Some(true);
+            let params1 = QueryParams {
+                key: Some(doc.get_id().into_owned()),
+                ..Default::default()
+            };
+            let params2 = QueryParams {
+                include_docs: Some(true),
+                ..Default::default()
+            };
             let mut params3 = QueryParams::default();
 
             let params = vec![params1, params2, params3];

--- a/couch_rs/src/types/find.rs
+++ b/couch_rs/src/types/find.rs
@@ -137,9 +137,9 @@ impl SelectAll {
     }
 }
 
-impl Into<serde_json::Value> for &SelectAll {
-    fn into(self) -> Value {
-        serde_json::to_value(&self).expect("can not convert into json")
+impl From<&SelectAll> for serde_json::Value {
+    fn from(s: &SelectAll) -> Self {
+        serde_json::to_value(&s).expect("can not convert into json")
     }
 }
 
@@ -250,15 +250,15 @@ impl FindQuery {
     }
 }
 
-impl Into<serde_json::Value> for FindQuery {
-    fn into(self) -> Value {
-        serde_json::to_value(&self).expect("can not convert into json")
+impl From<FindQuery> for serde_json::Value {
+    fn from(q: FindQuery) -> Self {
+        serde_json::to_value(&q).expect("can not convert into json")
     }
 }
 
-impl Into<serde_json::Value> for &FindQuery {
-    fn into(self) -> Value {
-        serde_json::to_value(&self).expect("can not convert into json")
+impl From<&FindQuery> for serde_json::Value {
+    fn from(q: &FindQuery) -> Self {
+        serde_json::to_value(&q).expect("can not convert into json")
     }
 }
 

--- a/couch_rs/src/types/view.rs
+++ b/couch_rs/src/types/view.rs
@@ -84,15 +84,15 @@ impl CouchFunc {
     }
 }
 
-impl Into<serde_json::Value> for CouchViews {
-    fn into(self) -> Value {
-        serde_json::to_value(self).unwrap()
+impl From<CouchViews> for serde_json::Value {
+    fn from(v: CouchViews) -> Self {
+        serde_json::to_value(v).unwrap()
     }
 }
 
-impl Into<serde_json::Value> for CouchFunc {
-    fn into(self) -> Value {
-        serde_json::to_value(self).unwrap()
+impl From<CouchFunc> for serde_json::Value {
+    fn from(f: CouchFunc) -> Self {
+        serde_json::to_value(f).unwrap()
     }
 }
 
@@ -110,8 +110,8 @@ impl CouchUpdate {
     }
 }
 
-impl Into<serde_json::Value> for CouchUpdate {
-    fn into(self) -> Value {
-        serde_json::to_value(self).unwrap()
+impl From<CouchUpdate> for serde_json::Value {
+    fn from(u: CouchUpdate) -> Self {
+        serde_json::to_value(u).unwrap()
     }
 }


### PR DESCRIPTION
This PR uses a `&mut` of a document instead of taking full ownership of the document passed.
Main reason for this is to be able to do something like:

```rust
                    // create the document
                    match db.create(&mut doc).await {
                        Ok(r) => println!("Document was created with ID: {} and Rev: {}", r.id, r.rev),
                        Err(err) => println!("error creating document {}: {:?}", doc, err),
                    }
```

so the document passed can still be referred to after executing an operation, otherwise only the Ok branch provides the document and the Err branch does not (so it's not possible to log the document for example, on error situations, without previously cloning the document which would be done before knowing if operation will succeed or not)

Also the operations taking a single document and operations taking multiple documents (e.g. bulk_docs) now have a closer signature (DocumentCreatedResult and Vec<DocumentCreatedResult>)