### PR TITLE
Changes stream

### DIFF
--- a/couch_rs/Cargo.toml
+++ b/couch_rs/Cargo.toml
@@ -22,10 +22,15 @@ couch_rs_derive = { version = "0.8.30", optional = true, path = "../couch_rs_der
 url = "2"
 tokio = { version = "1", features = ["rt-multi-thread"] }
 base64 = "0.13"
+tokio-util = "0.6.7"
+bytes = "1.0.1"
+tokio-stream = { version = "0.1.6", features = ["io-util"] }
+futures-util = "0.3.15"
+futures-core = "0.3.15"
 
 [dependencies.reqwest]
 version = "0.11"
-features = ["json", "gzip", "cookies"]
+features = ["json", "gzip", "cookies", "stream"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/couch_rs/src/changes.rs
+++ b/couch_rs/src/changes.rs
@@ -1,10 +1,10 @@
 use crate::client::Client;
-use futures_util::{ready, FutureExt, StreamExt, TryStreamExt};
 use futures_core::{Future, Stream};
+use futures_util::{ready, FutureExt, StreamExt, TryStreamExt};
 use reqwest::StatusCode;
 use reqwest::{Method, Response};
-use std::io;
 use std::collections::HashMap;
+use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::io::AsyncBufReadExt;
@@ -14,6 +14,9 @@ use tokio_util::io::StreamReader;
 use crate::error::{CouchError, CouchResult};
 use crate::types::changes::{ChangeEvent, Event};
 
+/// The stream for the `_changes` endpoint.
+///
+/// This is returned from [Database::changes].
 pub struct ChangesStream {
     last_seq: Option<String>,
     client: Client,
@@ -30,6 +33,7 @@ enum ChangesStreamState {
 }
 
 impl ChangesStream {
+    /// Create a new changes stream.
     pub fn new(client: Client, database: String, last_seq: Option<String>) -> Self {
         let mut params = HashMap::new();
         params.insert("feed".to_string(), "continuous".to_string());
@@ -38,6 +42,7 @@ impl ChangesStream {
         Self::with_params(client, database, last_seq, params)
     }
 
+    /// Create a new changes stream with params.
     pub fn with_params(
         client: Client,
         database: String,
@@ -54,10 +59,15 @@ impl ChangesStream {
         }
     }
 
+    /// Set the starting seq.
     pub fn set_last_seq(&mut self, last_seq: Option<String>) {
         self.last_seq = last_seq;
     }
 
+    /// Set infinite mode.
+    ///
+    /// If set to true, the changes stream will wait and poll for changes. Otherwise,
+    /// the stream will return all changes until now and then close.
     pub fn set_infinite(&mut self, infinite: bool) {
         self.infinite = infinite;
         let timeout = match infinite {
@@ -67,10 +77,12 @@ impl ChangesStream {
         self.params.insert("timeout".to_string(), timeout);
     }
 
+    /// Get the last retrieved seq.
     pub fn last_seq(&self) -> &Option<String> {
         &self.last_seq
     }
 
+    /// Whether this stream is running in infinite mode.
     pub fn infinite(&self) -> bool {
         self.infinite
     }
@@ -99,9 +111,10 @@ impl Stream for ChangesStream {
                     Err(err) => return Poll::Ready(Some(Err(err))),
                     Ok(res) => match res.status().is_success() {
                         true => {
-                            let stream = res
-                                .bytes_stream()
-                                .map_err(|err| io::Error::new(io::ErrorKind::Other, format!("{}", err)));
+                            let stream = res.bytes_stream().map_err(|err| {
+                                eprintln!("orig err {:#?}", err);
+                                io::Error::new(io::ErrorKind::Other, err)
+                            });
                             let reader = StreamReader::new(stream);
                             let lines = Box::pin(LinesStream::new(reader.lines()));
                             ChangesStreamState::Reading(lines)
@@ -118,17 +131,30 @@ impl Stream for ChangesStream {
                     let line = ready!(lines.poll_next_unpin(cx));
                     match line {
                         None => ChangesStreamState::Idle,
-                        Some(Err(e)) => {
-                            return Poll::Ready(Some(Err(CouchError::new(
-                                format!("{}", e),
-                                StatusCode::from_u16(500).unwrap(),
-                            ))))
+                        Some(Err(err)) => {
+                            let inner = err.get_ref().and_then(|err| err.downcast_ref::<reqwest::Error>());
+                            match inner {
+                                Some(reqwest_err) if reqwest_err.is_timeout() && self.infinite => {
+                                    ChangesStreamState::Idle
+                                }
+                                Some(reqwest_err) => {
+                                    return Poll::Ready(Some(Err(CouchError::new(
+                                        reqwest_err.to_string(),
+                                        reqwest_err.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                                    ))));
+                                }
+                                _ => {
+                                    return Poll::Ready(Some(Err(CouchError::new(
+                                        format!("{}", err),
+                                        StatusCode::from_u16(500).unwrap(),
+                                    ))));
+                                }
+                            }
                         }
                         Some(Ok(line)) if line.is_empty() => continue,
                         Some(Ok(line)) => match serde_json::from_str::<Event>(&line) {
                             Ok(Event::Change(event)) => {
                                 self.last_seq = Some(event.seq.clone());
-                                // eprintln!("event {:?}", event);
                                 return Poll::Ready(Some(Ok(event)));
                             }
                             Ok(Event::Finished(event)) => {
@@ -136,11 +162,9 @@ impl Stream for ChangesStream {
                                 if !self.infinite {
                                     return Poll::Ready(None);
                                 }
-                                // eprintln!("event {:?}", event);
                                 ChangesStreamState::Idle
                             }
                             Err(e) => {
-                                // eprintln!("Decoding error {} on line {}", e, line);
                                 return Poll::Ready(Some(Err(e.into())));
                             }
                         },
@@ -148,5 +172,44 @@ impl Stream for ChangesStream {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::client::Client;
+    use futures_util::StreamExt;
+    use serde_json::{json, Value};
+    #[tokio::test]
+    async fn should_get_changes() {
+        let client = Client::new_local_test().unwrap();
+        let db = client.db("should_get_changes").await.unwrap();
+        let mut changes = db.changes(None);
+        changes.set_infinite(true);
+        let t = tokio::spawn({
+            let db = db.clone();
+            async move {
+                let mut docs: Vec<Value> = (0..10)
+                    .map(|idx| {
+                        json!({
+                            "_id": format!("test_{}", idx),
+                            "count": idx,
+                        })
+                    })
+                    .collect();
+
+                db.bulk_docs(&mut docs).await.expect("should insert 10 documents");
+            }
+        });
+
+        let mut collected_changes = vec![];
+        while let Some(change) = changes.next().await {
+            collected_changes.push(change);
+            if collected_changes.len() == 10 {
+                break;
+            }
+        }
+        assert!(collected_changes.len() == 10);
+        t.await.unwrap();
     }
 }

--- a/couch_rs/src/changes.rs
+++ b/couch_rs/src/changes.rs
@@ -1,0 +1,152 @@
+use crate::client::Client;
+use futures_util::{ready, FutureExt, StreamExt, TryStreamExt};
+use futures_core::{Future, Stream};
+use reqwest::StatusCode;
+use reqwest::{Method, Response};
+use std::io;
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::AsyncBufReadExt;
+use tokio_stream::wrappers::LinesStream;
+use tokio_util::io::StreamReader;
+
+use crate::error::{CouchError, CouchResult};
+use crate::types::changes::{ChangeEvent, Event};
+
+pub struct ChangesStream {
+    last_seq: Option<String>,
+    client: Client,
+    database: String,
+    state: ChangesStreamState,
+    params: HashMap<String, String>,
+    infinite: bool,
+}
+
+enum ChangesStreamState {
+    Idle,
+    Requesting(Pin<Box<dyn Future<Output = CouchResult<Response>>>>),
+    Reading(Pin<Box<dyn Stream<Item = io::Result<String>>>>),
+}
+
+impl ChangesStream {
+    pub fn new(client: Client, database: String, last_seq: Option<String>) -> Self {
+        let mut params = HashMap::new();
+        params.insert("feed".to_string(), "continuous".to_string());
+        params.insert("timeout".to_string(), "0".to_string());
+        params.insert("include_docs".to_string(), "true".to_string());
+        Self::with_params(client, database, last_seq, params)
+    }
+
+    pub fn with_params(
+        client: Client,
+        database: String,
+        last_seq: Option<String>,
+        params: HashMap<String, String>,
+    ) -> Self {
+        Self {
+            client,
+            database,
+            params,
+            state: ChangesStreamState::Idle,
+            infinite: false,
+            last_seq,
+        }
+    }
+
+    pub fn set_last_seq(&mut self, last_seq: Option<String>) {
+        self.last_seq = last_seq;
+    }
+
+    pub fn set_infinite(&mut self, infinite: bool) {
+        self.infinite = infinite;
+        let timeout = match infinite {
+            true => "60000".to_string(),
+            false => "0".to_string(),
+        };
+        self.params.insert("timeout".to_string(), timeout);
+    }
+
+    pub fn last_seq(&self) -> &Option<String> {
+        &self.last_seq
+    }
+
+    pub fn infinite(&self) -> bool {
+        self.infinite
+    }
+}
+
+async fn get_changes(client: Client, database: String, params: HashMap<String, String>) -> CouchResult<Response> {
+    let path = format!("{}/_changes", database);
+    let res = client.req(Method::GET, path, Some(params)).send().await?;
+    Ok(res)
+}
+
+impl Stream for ChangesStream {
+    type Item = CouchResult<ChangeEvent>;
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            self.state = match self.state {
+                ChangesStreamState::Idle => {
+                    let mut params = self.params.clone();
+                    if let Some(seq) = &self.last_seq {
+                        params.insert("since".to_string(), seq.clone());
+                    }
+                    let fut = get_changes(self.client.clone(), self.database.clone(), params);
+                    ChangesStreamState::Requesting(Box::pin(fut))
+                }
+                ChangesStreamState::Requesting(ref mut fut) => match ready!(fut.poll_unpin(cx)) {
+                    Err(err) => return Poll::Ready(Some(Err(err))),
+                    Ok(res) => match res.status().is_success() {
+                        true => {
+                            let stream = res
+                                .bytes_stream()
+                                .map_err(|err| io::Error::new(io::ErrorKind::Other, format!("{}", err)));
+                            let reader = StreamReader::new(stream);
+                            let lines = Box::pin(LinesStream::new(reader.lines()));
+                            ChangesStreamState::Reading(lines)
+                        }
+                        false => {
+                            return Poll::Ready(Some(Err(CouchError::new(
+                                res.status().canonical_reason().unwrap().to_string(),
+                                res.status(),
+                            ))))
+                        }
+                    },
+                },
+                ChangesStreamState::Reading(ref mut lines) => {
+                    let line = ready!(lines.poll_next_unpin(cx));
+                    match line {
+                        None => ChangesStreamState::Idle,
+                        Some(Err(e)) => {
+                            return Poll::Ready(Some(Err(CouchError::new(
+                                format!("{}", e),
+                                StatusCode::from_u16(500).unwrap(),
+                            ))))
+                        }
+                        Some(Ok(line)) if line.is_empty() => continue,
+                        Some(Ok(line)) => match serde_json::from_str::<Event>(&line) {
+                            Ok(Event::Change(event)) => {
+                                self.last_seq = Some(event.seq.clone());
+                                // eprintln!("event {:?}", event);
+                                return Poll::Ready(Some(Ok(event)));
+                            }
+                            Ok(Event::Finished(event)) => {
+                                self.last_seq = Some(event.last_seq.clone());
+                                if !self.infinite {
+                                    return Poll::Ready(None);
+                                }
+                                // eprintln!("event {:?}", event);
+                                ChangesStreamState::Idle
+                            }
+                            Err(e) => {
+                                // eprintln!("Decoding error {} on line {}", e, line);
+                                return Poll::Ready(Some(Err(e.into())));
+                            }
+                        },
+                    }
+                }
+            }
+        }
+    }
+}

--- a/couch_rs/src/database.rs
+++ b/couch_rs/src/database.rs
@@ -1037,7 +1037,14 @@ impl Database {
         }
     }
 
-    pub async fn changes(&self, last_seq: Option<String>) -> ChangesStream {
+    /// A streaming handler for the CouchDB `_changes` endpoint.
+    /// 
+    /// See the [CouchDB docs](https://docs.couchdb.org/en/stable/api/database/changes.html)
+    /// for details on the semantics.
+    ///
+    /// It can return all changes from a `seq` string, and can optionally run in infinite (live)
+    /// mode.
+    pub fn changes(&self, last_seq: Option<String>) -> ChangesStream {
         ChangesStream::new(self._client.clone(), self.name.clone(), last_seq)
     }
 }

--- a/couch_rs/src/database.rs
+++ b/couch_rs/src/database.rs
@@ -1,3 +1,4 @@
+use crate::changes::ChangesStream;
 use crate::document::{DocumentCollection, TypedCouchDocument};
 use crate::error::{CouchError, CouchResult};
 use crate::types::design::DesignCreated;
@@ -1034,6 +1035,10 @@ impl Database {
             // Created and alright
             None => Ok(true),
         }
+    }
+
+    pub async fn changes(&self, last_seq: Option<String>) -> ChangesStream {
+        ChangesStream::new(self._client.clone(), self.name.clone(), last_seq)
     }
 }
 

--- a/couch_rs/src/lib.rs
+++ b/couch_rs/src/lib.rs
@@ -195,6 +195,8 @@ pub mod model;
 /// Data types to support CouchDB operations.
 pub mod types;
 
+mod changes;
+
 pub use client::Client;
 
 #[allow(unused_mut, unused_variables)]

--- a/couch_rs/src/types/changes.rs
+++ b/couch_rs/src/types/changes.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[serde(untagged)]
+pub enum Event {
+    Change(ChangeEvent),
+    Finished(FinishedEvent),
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub struct ChangeEvent {
+    pub seq: String,
+    pub id: String,
+    pub changes: Vec<Change>,
+
+    #[serde(default)]
+    pub deleted: bool,
+
+    #[serde(default)]
+    pub doc: Option<serde_json::Value>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub struct Change {
+    pub rev: String,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub struct FinishedEvent {
+    pub last_seq: String,
+    pub pending: Option<u64>, // not available on CouchDB 1.0
+}

--- a/couch_rs/src/types/mod.rs
+++ b/couch_rs/src/types/mod.rs
@@ -1,7 +1,8 @@
-pub mod view;
+pub mod changes;
 pub mod design;
-pub mod system;
 pub mod document;
 pub mod find;
 pub mod index;
 pub mod query;
+pub mod system;
+pub mod view;


### PR DESCRIPTION
I needed support for the [`_changes`](https://docs.couchdb.org/en/stable/api/database/changes.html) endpoint.
This PR adds streaming support for the line-based protocol. It supports both infinite mode and getting all available changes and then returning.