### PR TITLE
add bulk upsert feature

### DIFF
--- a/couch_rs/src/lib.rs
+++ b/couch_rs/src/lib.rs
@@ -925,5 +925,40 @@ mod couch_rs_tests {
             t.await.unwrap();
             teardown(client, "should_bulk_insert_and_get_many_docs").await;
         }
+
+        #[tokio::test]
+        async fn should_bulk_upsert_docs() {
+            let (client, db, _doc) = setup("should_bulk_upsert_docs").await;
+            let count = 3;
+            let mut docs: Vec<Value> = (0..count)
+                .map(|idx| {
+                    json!({
+                        "_id": format!("bd_{}", idx),
+                        "value": "hello",
+                        "count": idx,
+                    })
+                })
+                .collect();
+
+            db.bulk_docs(&mut docs).await.expect("should insert documents");
+
+            for doc in docs.iter_mut() {
+                doc.as_object_mut().unwrap().insert("updated".to_string(), serde_json::Value::Bool(true));
+            }
+
+            let res = db.bulk_upsert(&mut docs).await.expect("should upsert documents");
+
+            for i in 0..count {
+                assert!(res[i].as_ref().unwrap().rev == docs[i].get_rev());
+            }
+            let ids: Vec<String> = (0..count).map(|idx| format!("bd_{}", idx)).collect();
+            let docs = db.get_bulk::<Value>(ids).await.expect("should get documents");
+
+            for i in 0..count {
+                assert!(docs[i].get_rev() == res[i].as_ref().unwrap().rev);
+                assert!(docs[i].as_object().expect("should be an object").get("updated").expect("should have updated key") == true);
+            }
+            teardown(client, "should_bulk_upsert_docs").await;
+        }
     }
 }


### PR DESCRIPTION
This adds a `bulk_upsert` method. This will first fetch the latest rev for each document that does not have a rev set. It will then update the passed-in docs with that rev and insert all documents into the database.
