### PR TITLE
Key for view can now be of type other than String

### DIFF
--- a/couch_rs/src/database.rs
+++ b/couch_rs/src/database.rs
@@ -314,7 +314,7 @@ impl Database {
     pub async fn get_bulk_params<T: TypedCouchDocument>(
         &self,
         ids: Vec<DocumentId>,
-        params: Option<QueryParams>,
+        params: Option<QueryParams<DocumentId>>,
     ) -> CouchResult<DocumentCollection<T>> {
         let mut options = params.unwrap_or_default();
 
@@ -497,7 +497,10 @@ impl Database {
         Ok(results.results)
     }
 
-    pub async fn get_all_params_raw(&self, params: Option<QueryParams>) -> CouchResult<DocumentCollection<Value>> {
+    pub async fn get_all_params_raw(
+        &self,
+        params: Option<QueryParams<DocumentId>>,
+    ) -> CouchResult<DocumentCollection<Value>> {
         self.get_all_params(params).await
     }
 
@@ -505,7 +508,7 @@ impl Database {
     /// Parameters description can be found here: [api-ddoc-view](https://docs.couchdb.org/en/latest/api/ddoc/views.html#api-ddoc-view)
     pub async fn get_all_params<T: TypedCouchDocument>(
         &self,
-        params: Option<QueryParams>,
+        params: Option<QueryParams<DocumentId>>,
     ) -> CouchResult<DocumentCollection<T>> {
         let mut options = params.unwrap_or_default();
 
@@ -882,7 +885,7 @@ impl Database {
         &self,
         design_name: &str,
         view_name: &str,
-        options: Option<QueryParams>,
+        options: Option<QueryParams<Value>>,
     ) -> CouchResult<ViewCollection<Value, Value, Value>> {
         self.query(design_name, view_name, options).await
     }
@@ -934,11 +937,15 @@ impl Database {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn query<K: DeserializeOwned, V: DeserializeOwned, T: TypedCouchDocument>(
+    pub async fn query<
+        K: Serialize + DeserializeOwned + PartialEq + std::fmt::Debug + Clone,
+        V: DeserializeOwned,
+        T: TypedCouchDocument,
+    >(
         &self,
         design_name: &str,
         view_name: &str,
-        mut options: Option<QueryParams>,
+        mut options: Option<QueryParams<K>>,
     ) -> CouchResult<ViewCollection<K, V, T>> {
         if options.is_none() {
             options = Some(QueryParams::default());

--- a/couch_rs/src/lib.rs
+++ b/couch_rs/src/lib.rs
@@ -664,18 +664,22 @@ mod couch_rs_tests {
 
             // executing 'all' view querying with keys containing 1 key should result in 1 and 0 entries, respectively
             assert_eq!(
-                db.query_raw(view_name, view_name, Some(QueryParams::from_keys(vec![id.clone()])))
-                    .await
-                    .unwrap()
-                    .rows
-                    .len(),
+                db.query_raw(
+                    view_name,
+                    view_name,
+                    Some(QueryParams::from_keys(vec![id.clone().into()]))
+                )
+                .await
+                .unwrap()
+                .rows
+                .len(),
                 1
             );
             assert_eq!(
                 db.query_raw(
                     single_view_name,
                     single_view_name,
-                    Some(QueryParams::from_keys(vec![id])),
+                    Some(QueryParams::from_keys(vec![id.into()])),
                 )
                 .await
                 .unwrap()
@@ -740,7 +744,7 @@ mod couch_rs_tests {
 
             // executing 'all' view querying with a specific key should result in 1 and 0 entries, respectively
             let one_key = QueryParams {
-                key: Some(doc.get_id().into_owned()),
+                key: Some(doc.get_id().into()),
                 ..Default::default()
             };
 


### PR DESCRIPTION
I'm learning CouchDB by reading the documentatio, and saw the ability to index views by type other than String. This looked pretty interesting, and actually needed it for the school project where I decided to use couchdb (cause it seems cool).

I only did the required change for views, not for document, where they are still indexed by DocumentId (a.k.a String).

This introduce breaking change, mostly due to needing to convert String to Value for query_raw (nothing a .into() can't handle)

I also executed the tests.