### PR TITLE
Convert JSON decode errors from reqwest

### DIFF
--- a/couch_rs/Cargo.toml
+++ b/couch_rs/Cargo.toml
@@ -36,6 +36,7 @@ default-features = false
 
 [dev-dependencies]
 tokio = { version = "^1.14", features = ["rt-multi-thread", "macros"] }
+http = { version = "0.2" }
 
 [features]
 default = ["derive", "native-tls"]

--- a/couch_rs/src/error.rs
+++ b/couch_rs/src/error.rs
@@ -28,7 +28,7 @@ pub struct ErrorDetails {
 pub struct ErrorMessage {
     /// Detailed error message
     pub message: String,
-    upstream: Option<UpstreamError>,
+    pub(crate) upstream: Option<UpstreamError>,
 }
 
 type UpstreamError = Arc<dyn error::Error + Send + Sync + 'static>;


### PR DESCRIPTION
Convert JSON decode errors from reqwest to the relevant `CouchError` variant.

Use an extension trait to do this.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>