### PR TITLE
Improve indexing

### DIFF
--- a/couch_rs/src/database.rs
+++ b/couch_rs/src/database.rs
@@ -1053,14 +1053,15 @@ impl Database {
     ///     let client = couch_rs::Client::new_local_test()?;
     ///     let db = client.db(TEST_DB).await?;
     /// 
-    ///     let index_name = "email";
+    ///     let index_name = "name";
     ///     let index_def = IndexFields {
     ///         fields: vec!{
-    ///             SortSpec::Simple("email".to_string())
+    ///             SortSpec::Simple("lastname".to_string()),
+    ///             SortSpec::Simple("firstname".to_string()),
     ///         }
     ///     };
     /// 
-    ///     match db.insert_index(index_name, index_def, None, None, None).await {
+    ///     match db.insert_index(index_name, index_def, None, None).await {
     ///         Ok(doc_created) => match doc_created.result {
     ///             // Expected value of 'r' is 'created' if the index did not previously exist or 
     ///             // exists otherwise.
@@ -1145,7 +1146,7 @@ impl Database {
 
             // We look for our index
             for i in index_map.clone().into_iter() {
-                if i.name == index.name {
+                if i == index {
                     // Found? Ok let's return
                     continue
                 }

--- a/couch_rs/src/database.rs
+++ b/couch_rs/src/database.rs
@@ -7,7 +7,7 @@ use crate::{
         design::DesignCreated,
         document::{DocumentCreatedDetails, DocumentCreatedResponse, DocumentCreatedResult, DocumentId},
         find::{FindQuery, FindResult},
-        index::{DatabaseIndexList, Index, IndexFields, IndexType},
+        index::{DatabaseIndexList, IndexFields, IndexType},
         query::{QueriesCollection, QueriesParams, QueryParams},
         view::ViewCollection,
     },

--- a/couch_rs/src/types/index.rs
+++ b/couch_rs/src/types/index.rs
@@ -32,6 +32,8 @@ pub enum IndexType {
     Json,
     #[serde(rename = "text")]
     Text,
+    #[serde(rename = "special")]
+    Special, // reserved for primary index
 }
 
 impl fmt::Display for IndexType {
@@ -40,6 +42,7 @@ impl fmt::Display for IndexType {
         match self {
             IndexType::Json => write!(f, "json"),
             IndexType::Text => write!(f, "text"),
+            IndexType::Special => write!(f, "special"),
         }
     }
 }

--- a/couch_rs/src/types/index.rs
+++ b/couch_rs/src/types/index.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::fmt;
 use document::DocumentId;
 use find::SortSpec;
 use serde::{Deserialize, Serialize};
@@ -21,14 +22,26 @@ pub struct Index {
     pub ddoc: Option<DocumentId>,
     pub name: String,
     #[serde(rename = "type")]
-    pub index_type: IndexType,
+    pub index_type: Option<IndexType>,
     pub def: IndexFields,
 }
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Clone)]
 pub enum IndexType {
+    #[serde(rename = "json")]
     Json,
+    #[serde(rename = "text")]
     Text,
+}
+
+impl fmt::Display for IndexType {
+
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            IndexType::Json => write!(f, "json"),
+            IndexType::Text => write!(f, "text"),
+        }
+    }
 }
 
 /// Database index list abstraction

--- a/couch_rs/src/types/index.rs
+++ b/couch_rs/src/types/index.rs
@@ -21,8 +21,14 @@ pub struct Index {
     pub ddoc: Option<DocumentId>,
     pub name: String,
     #[serde(rename = "type")]
-    pub index_type: String,
+    pub index_type: IndexType,
     pub def: IndexFields,
+}
+
+#[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Clone)]
+pub enum IndexType {
+    Json,
+    Text,
 }
 
 /// Database index list abstraction


### PR DESCRIPTION
 - Update documentation of `insert_index` function
 - Implement an enum for IndexType
 - Make `insert_index` take all fields included in types::index::Index
 - Remove `ensure_index` as it no longer has a use