### PR TITLE
fix RUSTSEC-2023-0018, cargo update, bumpup base64

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![docs.rs](https://docs.rs/couch_rs/badge.svg)](https://docs.rs/couch_rs)
 ![Build](https://img.shields.io/github/workflow/status/mibes/couch-rs/Rust)
 ![License](https://img.shields.io/crates/l/couch_rs.svg)
-[![dependency status](https://deps.rs/crate/couch_rs/0.9.0/status.svg)](https://deps.rs/crate/couch_rs)
+[![dependency status](https://deps.rs/crate/couch_rs/0.9.1/status.svg)](https://deps.rs/crate/couch_rs)
 ![Downloads](https://img.shields.io/crates/d/couch_rs.svg)
 
 ## Documentation

--- a/couch_rs/Cargo.toml
+++ b/couch_rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "couch_rs"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Mathieu Amiot <mathieu.amiot@yellowinnovation.fr>", "mibes <mibes@mibesco.com>"]
 license = "MIT/Apache-2.0"
 description = "CouchDB library for Rust"
@@ -18,7 +18,7 @@ include = [
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-couch_rs_derive = { version = "0.9.0", optional = true, path = "../couch_rs_derive" }
+couch_rs_derive = { version = "0.9.1", optional = true, path = "../couch_rs_derive" }
 url = "2"
 tokio = { version = "^1.14", features = ["rt-multi-thread"] }
 base64 = "0.20"

--- a/couch_rs/Cargo.toml
+++ b/couch_rs/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "couch_rs"
 version = "0.9.1"
-authors = ["Mathieu Amiot <mathieu.amiot@yellowinnovation.fr>", "mibes <mibes@mibesco.com>"]
+authors = [
+    "Mathieu Amiot <mathieu.amiot@yellowinnovation.fr>",
+    "mibes <mibes@mibesco.com>",
+]
 license = "MIT/Apache-2.0"
 description = "CouchDB library for Rust"
 readme = "README.md"
@@ -10,10 +13,7 @@ repository = "https://github.com/mibes/couch-rs"
 keywords = ["couchdb", "orm", "database", "nosql"]
 categories = ["database"]
 edition = "2018"
-include = [
-    "**/*.rs",
-    "Cargo.toml"
-]
+include = ["**/*.rs", "Cargo.toml"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -21,8 +21,8 @@ serde_json = "1"
 couch_rs_derive = { version = "0.9.1", optional = true, path = "../couch_rs_derive" }
 url = "2"
 tokio = { version = "^1.14", features = ["rt-multi-thread"] }
-base64 = "0.20"
-tokio-util = {version = "0.7", features = ["io"]}
+base64 = "0.21"
+tokio-util = { version = "0.7", features = ["io"] }
 bytes = "1"
 tokio-stream = { version = "0.1", features = ["io-util"] }
 futures-util = "0.3"

--- a/couch_rs/src/client.rs
+++ b/couch_rs/src/client.rs
@@ -4,7 +4,7 @@ use crate::{
     management::{ClusterSetup, ClusterSetupGetResponse, EnsureDbsExist, Membership},
     types::system::{CouchResponse, CouchStatus, DbInfo},
 };
-use base64::write::EncoderWriter as Base64Encoder;
+use base64::{engine::general_purpose};
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use reqwest::{
     self,
@@ -106,7 +106,7 @@ impl Client {
         if let Some(username) = username {
             let mut header_value = b"Basic ".to_vec();
             {
-                let mut encoder = Base64Encoder::from(&mut header_value, &base64::engine::DEFAULT_ENGINE);
+                let mut encoder = base64::write::EncoderWriter::new(&mut header_value, &general_purpose::STANDARD);
                 // The unwraps here are fine because Vec::write* is infallible.
                 write!(encoder, "{}:", username).unwrap();
                 if let Some(password) = password {

--- a/couch_rs_derive/Cargo.toml
+++ b/couch_rs_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "couch_rs_derive"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["mibes <mibes@mibesco.com>"]
 license = "MIT/Apache-2.0"
 description = "CouchDB library for Rust"

--- a/deny.toml
+++ b/deny.toml
@@ -72,7 +72,8 @@ unlicensed = "allow"
 allow = [
     "MIT",
     "Apache-2.0",
-    "BSD-3-Clause"
+    "BSD-3-Clause",
+    "Unicode-DFS-2016"
 ]
 # List of explictly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses


### PR DESCRIPTION
dependencies update to make cargo deny check happy