### PR TITLE
Fix the deprecated warning not properly displayed in the documentation

### DIFF
--- a/couch_rs/src/database.rs
+++ b/couch_rs/src/database.rs
@@ -1157,7 +1157,7 @@ impl Database {
     /// Method to ensure an index is created on the database with the following
     /// spec. Returns `true` when we created a new one, or `false` when the
     /// index was already existing.
-    /// #[deprecated(since="0.9.1", note="please use `insert_index` instead")]
+    #[deprecated(since="0.9.1", note="please use `insert_index` instead")]
     pub async fn ensure_index(&self, name: &str, spec: IndexFields) -> CouchResult<bool> {
         let result: DesignCreated = self.insert_index(name, spec, None, None).await?;
         let r = match result.result {


### PR DESCRIPTION
The deprecated warning of `Database::ensure_index()` is written in the doc comments. Written it as attribute macro make it displayed properly.