### PR TITLE
Add a typed wrapper for Database

### DIFF
--- a/couch_rs/examples/typed_documents/main.rs
+++ b/couch_rs/examples/typed_documents/main.rs
@@ -11,7 +11,7 @@ pub struct TestDoc {
     /// `CouchDB` stores its documents in a B+ tree. Each additional or updated document is stored as
     /// a leaf node, and may require re-writing intermediary and parent nodes. You may be able to take
     /// advantage of sequencing your own ids more effectively than the automatically generated ids if
-    /// you can arrange them to be sequential yourself. (https://docs.couchdb.org/en/stable/best-practices/documents.html)
+    /// you can arrange them to be sequential yourself. <https://docs.couchdb.org/en/stable/best-practices/documents.html>
     #[serde(skip_serializing_if = "String::is_empty")]
     pub _id: DocumentId,
     /// Document Revision, provided by `CouchDB`, helps negotiating conflicts

--- a/couch_rs/src/client.rs
+++ b/couch_rs/src/client.rs
@@ -51,7 +51,7 @@ pub(crate) async fn is_ok(request: RequestBuilder) -> bool {
 /// It is also responsible for the creation/access/destruction of databases.
 #[derive(Debug, Clone)]
 pub struct Client {
-    _client: reqwest::Client,
+    client: reqwest::Client,
     _gzip: bool,
     _timeout: Option<u64>,
     uri: Url,
@@ -66,21 +66,21 @@ const DEFAULT_TIME_OUT: u64 = 10;
 impl Client {
     /// new creates a new Couch client with a default timeout of 10 seconds.
     /// The timeout is applied from when the request starts connecting until the response body has finished.
-    /// The URI has to be in this format: http://hostname:5984, for example: http://192.168.64.5:5984
+    /// The URI has to be in this format: <http://hostname:5984>, for example: <http://192.168.64.5:5984>
     pub fn new(uri: &str, username: &str, password: &str) -> CouchResult<Client> {
         Client::new_with_timeout(uri, Some(username), Some(password), Some(DEFAULT_TIME_OUT))
     }
 
     /// `new_no_auth` creates a new Couch client with a default timeout of 10 seconds. *Without authentication*.
     /// The timeout is applied from when the request starts connecting until the response body has finished.
-    /// The URI has to be in this format: http://hostname:5984, for example: http://192.168.64.5:5984
+    /// The URI has to be in this format: <http://hostname:5984>, for example: <http://192.168.64.5:5984>
     pub fn new_no_auth(uri: &str) -> CouchResult<Client> {
         Client::new_with_timeout(uri, None, None, Some(DEFAULT_TIME_OUT))
     }
 
     /// `new_local_test` creates a new Couch client *for testing purposes* with a default timeout of 10 seconds.
     /// The timeout is applied from when the request starts connecting until the response body has finished.
-    /// The URI that will be used is: http://hostname:5984, with a username of "admin" and a password
+    /// The URI that will be used is: <http://hostname:5984>, with a username of "admin" and a password
     /// of "password". Use this only for testing!!!
     pub fn new_local_test() -> CouchResult<Client> {
         Client::new_with_timeout(
@@ -91,7 +91,7 @@ impl Client {
         )
     }
 
-    /// `new_with_timeout` creates a new Couch client. The URI has to be in this format: http://hostname:5984,
+    /// `new_with_timeout` creates a new Couch client. The URI has to be in this format: <http://hostname:5984>,
     /// The timeout is applied from when the request starts connecting until the response body has finished.
     /// Timeout is in seconds.
     ///
@@ -103,7 +103,7 @@ impl Client {
         password: Option<&str>,
         timeout: Option<u64>,
     ) -> CouchResult<Client> {
-        let mut headers = header::HeaderMap::new();
+        let mut headers = HeaderMap::new();
 
         if let Some(username) = username {
             let mut header_value = b"Basic ".to_vec();
@@ -116,7 +116,7 @@ impl Client {
                 }
             }
 
-            let auth_header = header::HeaderValue::from_bytes(&header_value).expect("can not set AUTHORIZATION header");
+            let auth_header = HeaderValue::from_bytes(&header_value).expect("can not set AUTHORIZATION header");
             headers.insert(header::AUTHORIZATION, auth_header);
         }
 
@@ -127,7 +127,7 @@ impl Client {
         let client = client_builder.build()?;
 
         Ok(Client {
-            _client: client,
+            client,
             uri: parse_server(uri)?,
             _gzip: true,
             _timeout: timeout,
@@ -317,7 +317,7 @@ impl Client {
             }
         }
 
-        self._client
+        self.client
             .request(method, uri.as_str())
             .headers(construct_json_headers(Some(uri.as_str())))
     }

--- a/couch_rs/src/database.rs
+++ b/couch_rs/src/database.rs
@@ -826,10 +826,7 @@ impl Database {
     ///
     /// This will first fetch the latest rev for each document that does not have a rev set. It
     /// will then insert all documents into the database.
-    pub async fn bulk_upsert<T: TypedCouchDocument + Clone>(
-        &self,
-        docs: &mut [T],
-    ) -> CouchResult<Vec<DocumentCreatedResult>> {
+    pub async fn bulk_upsert<T: TypedCouchDocument>(&self, docs: &mut [T]) -> CouchResult<Vec<DocumentCreatedResult>> {
         // First collect all docs that do not have a rev set.
         let mut docs_without_rev = vec![];
         for (i, doc) in docs.iter().enumerate() {

--- a/couch_rs/src/document.rs
+++ b/couch_rs/src/document.rs
@@ -125,7 +125,7 @@ impl<T: TypedCouchDocument> DocumentCollection<T> {
             offset: doc.offset,
             total_rows: u32::try_from(items.len()).expect("total_rows > u32::MAX is not supported"),
             rows: items,
-            bookmark: Option::None,
+            bookmark: None,
         }
     }
 

--- a/couch_rs/src/error.rs
+++ b/couch_rs/src/error.rs
@@ -1,4 +1,4 @@
-use std::{error, fmt, sync::Arc};
+use std::{convert::From, error, fmt, sync::Arc};
 
 // Define our error types. These may be customized for our error handling cases.
 // Now we will be able to write our own errors, defer to an underlying error
@@ -121,7 +121,7 @@ impl error::Error for CouchError {
     }
 }
 
-impl std::convert::From<reqwest::Error> for CouchError {
+impl From<reqwest::Error> for CouchError {
     fn from(err: reqwest::Error) -> Self {
         CouchError::OperationFailed(ErrorDetails {
             id: None,
@@ -132,7 +132,7 @@ impl std::convert::From<reqwest::Error> for CouchError {
     }
 }
 
-impl std::convert::From<serde_json::Error> for CouchError {
+impl From<serde_json::Error> for CouchError {
     fn from(err: serde_json::Error) -> Self {
         CouchError::InvalidJson(ErrorMessage {
             message: err.to_string(),
@@ -141,7 +141,7 @@ impl std::convert::From<serde_json::Error> for CouchError {
     }
 }
 
-impl std::convert::From<url::ParseError> for CouchError {
+impl From<url::ParseError> for CouchError {
     fn from(err: url::ParseError) -> Self {
         CouchError::MalformedUrl(ErrorMessage {
             message: err.to_string(),

--- a/couch_rs/src/lib.rs
+++ b/couch_rs/src/lib.rs
@@ -185,6 +185,10 @@ mod macros {
 mod client;
 /// Database operations on a CouchDB Database.
 pub mod database;
+
+/// Typed Database operations on a CouchDB Database.
+pub mod typed;
+
 /// Document model to support CouchDB document operations.
 pub mod document;
 /// Error wrappers for the HTTP status codes returned by CouchDB.

--- a/couch_rs/src/lib.rs
+++ b/couch_rs/src/lib.rs
@@ -5,7 +5,7 @@
 //! This crate is an interface to `CouchDB` HTTP REST API. Works with stable Rust.
 //!
 //! This library is a spin-off based on the excellent work done by Mathieu Amiot and others at Yellow Innovation on the
-//! Sofa library. The original project can be found at https://github.com/YellowInnovation/sofa
+//! Sofa library. The original project can be found at <https://github.com/YellowInnovation/sofa>
 //!
 //! The Sofa library lacked support for async I/O, and missed a few essential operations we needed in our projects. That's
 //! why I've decided to create a new project based on the original Sofa code.

--- a/couch_rs/src/lib.rs
+++ b/couch_rs/src/lib.rs
@@ -103,6 +103,9 @@
 //! See the `database` module for additional usage examples. Or have a look at the `examples` in the
 //! GitHub repositiory.
 //!
+//! The `typed` module provides a typed wrapper around `Database` where all operations are performed on a specific generic type.
+//! This is useful when you want to work with a specific type of document for all operations on a database insteance as the compiler
+//! will flag any errors at compile time if different types are mixed using the same database instance.
 
 // Re-export #[derive(CouchDocument)].
 #[cfg(feature = "couch_rs_derive")]
@@ -189,7 +192,7 @@ mod client;
 /// Database operations on a `CouchDB` Database.
 pub mod database;
 
-/// Typed Database operations on a `CouchDB`` Database.
+/// Typed Database operations on a `CouchDB` Database.
 pub mod typed;
 
 /// Document model to support `CouchDB` document operations.

--- a/couch_rs/src/typed.rs
+++ b/couch_rs/src/typed.rs
@@ -1,0 +1,221 @@
+use std::marker::PhantomData;
+
+use serde::{de::DeserializeOwned, Serialize};
+use serde_json::Value;
+use tokio::sync::mpsc::Sender;
+
+use crate::changes::ChangesStream;
+use crate::client::Client;
+use crate::database::Database as RawDatabase;
+use crate::document::{DocumentCollection, TypedCouchDocument};
+use crate::error::CouchResult;
+use crate::types::design::DesignCreated;
+use crate::types::document::{DocumentCreatedResult, DocumentId};
+use crate::types::find::FindQuery;
+use crate::types::index::{DatabaseIndexList, IndexFields, IndexType};
+use crate::types::query::{QueriesParams, QueryParams};
+use crate::types::view::ViewCollection;
+
+/// Wraps a database that will create/read/update/delete documents of a specific type.
+/// This helps catching errors at compile time in case multiple instances of Database are used and each Database is supposed to handle a different type of document.
+pub struct Database<T: TypedCouchDocument> {
+    db: RawDatabase,
+    phantom: PhantomData<T>,
+}
+
+impl<T: TypedCouchDocument> Database<T> {
+    /// Creates a new typed Database instance.
+    pub fn new(name: String, client: Client) -> Self {
+        let db = RawDatabase::new(name, client);
+        Self {
+            db,
+            phantom: PhantomData,
+        }
+    }
+
+    // delegate all methods from RawDatabase
+
+    /// See [Database::name](crate::database::Database::name)
+    pub fn name(&self) -> &str {
+        self.db.name()
+    }
+
+    /// See [Database::compact](crate::database::Database::compact)
+    pub async fn compact(&self) -> bool {
+        self.db.compact().await
+    }
+
+    /// See [Database::compact_views](crate::database::Database::compact_views)
+    pub async fn compact_views(&self) -> bool {
+        self.db.compact_views().await
+    }
+
+    /// See [Database::compact_index](crate::database::Database::compact_index)
+    pub async fn compact_index(&self, index: &str) -> bool {
+        self.db.compact_index(index).await
+    }
+
+    /// See [Database::exists](crate::database::Database::exists)
+    pub async fn exists(&self, id: &str) -> bool {
+        self.db.exists(id).await
+    }
+
+    /// See [Database::get](crate::database::Database::get)
+    pub async fn get(&self, id: &str) -> CouchResult<T> {
+        self.db.get(id).await
+    }
+
+    /// See [Database::get_bulk](crate::database::Database::get_bulk)
+    pub async fn get_bulk(&self, ids: Vec<DocumentId>) -> CouchResult<DocumentCollection<T>> {
+        self.db.get_bulk(ids).await
+    }
+
+    /// See [Database::bulk_docs](crate::database::Database::bulk_docs)
+    pub async fn bulk_docs(&self, raw_docs: &mut [T]) -> CouchResult<Vec<DocumentCreatedResult>> {
+        self.db.bulk_docs(raw_docs).await
+    }
+
+    /// See [Database::get_bulk_params](crate::database::Database::get_bulk_params)
+    pub async fn get_bulk_params(
+        &self,
+        ids: Vec<DocumentId>,
+        params: Option<QueryParams<DocumentId>>,
+    ) -> CouchResult<DocumentCollection<T>> {
+        self.db.get_bulk_params(ids, params).await
+    }
+
+    /// See [Database::get_all](crate::database::Database::get_all)
+    pub async fn get_all(&self) -> CouchResult<DocumentCollection<T>> {
+        self.db.get_all().await
+    }
+
+    /// See [Database::get_all_batched](crate::database::Database::get_all_batched)
+    pub async fn get_all_batched(
+        &self,
+        tx: Sender<DocumentCollection<T>>,
+        batch_size: u64,
+        max_results: u64,
+    ) -> CouchResult<u64> {
+        self.db.get_all_batched(tx, batch_size, max_results).await
+    }
+
+    /// See [Database::find_batched](crate::database::Database::find_batched)
+    pub async fn find_batched(
+        &self,
+        query: FindQuery,
+        tx: Sender<DocumentCollection<T>>,
+        batch_size: u64,
+        max_results: u64,
+    ) -> CouchResult<u64> {
+        self.db.find_batched(query, tx, batch_size, max_results).await
+    }
+
+    /// See [Database::query_many_all_docs](crate::database::Database::query_many_all_docs)
+    pub async fn query_many_all_docs(
+        &self,
+        queries: QueriesParams,
+    ) -> CouchResult<Vec<ViewCollection<Value, Value, Value>>> {
+        self.db.query_many_all_docs(queries).await
+    }
+
+    /// See [Database::query_many](crate::database::Database::query_many)
+    pub async fn query_many(
+        &self,
+        design_name: &str,
+        view_name: &str,
+        queries: QueriesParams,
+    ) -> CouchResult<Vec<ViewCollection<Value, Value, Value>>> {
+        self.db.query_many(design_name, view_name, queries).await
+    }
+
+    /// See [Database::get_all_params](crate::database::Database::get_all_params)
+    pub async fn get_all_params(&self, params: Option<QueryParams<DocumentId>>) -> CouchResult<DocumentCollection<T>> {
+        self.db.get_all_params(params).await
+    }
+
+    /// See [Database::find](crate::database::Database::find)
+    pub async fn find(&self, query: &FindQuery) -> CouchResult<DocumentCollection<T>> {
+        self.db.find(query).await
+    }
+
+    /// See [Database::save](crate::database::Database::save)
+    pub async fn save(&self, doc: &mut T) -> DocumentCreatedResult {
+        self.db.save(doc).await
+    }
+
+    /// See [Database::create](crate::database::Database::create)
+    pub async fn create(&self, doc: &mut T) -> DocumentCreatedResult {
+        self.db.create(doc).await
+    }
+
+    /// See [Database::upsert](crate::database::Database::upsert)
+    pub async fn upsert(&self, doc: &mut T) -> DocumentCreatedResult {
+        self.db.upsert(doc).await
+    }
+
+    /// See [Database::bulk_upsert](crate::database::Database::bulk_upsert)
+    pub async fn bulk_upsert(&self, docs: &mut [T]) -> CouchResult<Vec<DocumentCreatedResult>> {
+        self.db.bulk_upsert(docs).await
+    }
+
+    /// See [Database::create_view](crate::database::Database::create_view)
+    pub async fn create_view<V: Into<serde_json::Value>>(
+        &self,
+        design_name: &str,
+        views: V,
+    ) -> CouchResult<DesignCreated> {
+        self.db.create_view(design_name, views).await
+    }
+
+    /// See [Database::query](crate::database::Database::query)
+    pub async fn query<K: Serialize + DeserializeOwned + PartialEq + std::fmt::Debug + Clone, V: DeserializeOwned>(
+        &self,
+        design_name: &str,
+        view_name: &str,
+        options: Option<QueryParams<K>>,
+    ) -> CouchResult<ViewCollection<K, V, T>> {
+        self.db.query(design_name, view_name, options).await
+    }
+
+    /// See [Database::execute_update](crate::database::Database::execute_update)
+    pub async fn execute_update(
+        &self,
+        design_id: &str,
+        name: &str,
+        document_id: &str,
+        body: Option<Value>,
+    ) -> CouchResult<String> {
+        self.db.execute_update(design_id, name, document_id, body).await
+    }
+
+    /// See [Database::remove](crate::database::Database::remove)
+    pub async fn remove(&self, doc: &T) -> bool {
+        self.db.remove(doc).await
+    }
+
+    /// See [Database::insert_index](crate::database::Database::insert_index)
+    pub async fn insert_index(
+        &self,
+        name: &str,
+        def: IndexFields,
+        index_type: Option<IndexType>,
+        ddoc: Option<DocumentId>,
+    ) -> CouchResult<DesignCreated> {
+        self.db.insert_index(name, def, index_type, ddoc).await
+    }
+
+    /// See [Database::read_indexes](crate::database::Database::read_indexes)
+    pub async fn read_indexes(&self) -> CouchResult<DatabaseIndexList> {
+        self.db.read_indexes().await
+    }
+
+    /// See [Database::delete_index](crate::database::Database::delete_index)
+    pub async fn delete_index(&self, ddoc: DocumentId, name: String) -> CouchResult<bool> {
+        self.db.delete_index(ddoc, name).await
+    }
+
+    /// See [Database::changes](crate::database::Database::changes)
+    pub fn changes(&self, last_seq: Option<serde_json::Value>) -> ChangesStream {
+        self.db.changes(last_seq)
+    }
+}

--- a/couch_rs/src/typed.rs
+++ b/couch_rs/src/typed.rs
@@ -25,6 +25,7 @@ pub struct Database<T: TypedCouchDocument> {
 
 impl<T: TypedCouchDocument> Database<T> {
     /// Creates a new typed Database instance.
+    #[must_use]
     pub fn new(name: String, client: Client) -> Self {
         let db = RawDatabase::new(name, client);
         Self {
@@ -35,47 +36,48 @@ impl<T: TypedCouchDocument> Database<T> {
 
     // delegate all methods from RawDatabase
 
-    /// See [Database::name](crate::database::Database::name)
+    /// See [`Database::name`](crate::database::Database::name)
+    #[must_use]
     pub fn name(&self) -> &str {
         self.db.name()
     }
 
-    /// See [Database::compact](crate::database::Database::compact)
+    /// See [`Database::compact`](crate::database::Database::compact)
     pub async fn compact(&self) -> bool {
         self.db.compact().await
     }
 
-    /// See [Database::compact_views](crate::database::Database::compact_views)
+    /// See [`Database::compact_views`](crate::database::Database::compact_views)
     pub async fn compact_views(&self) -> bool {
         self.db.compact_views().await
     }
 
-    /// See [Database::compact_index](crate::database::Database::compact_index)
+    /// See [`Database::compact_index`](crate::database::Database::compact_index)
     pub async fn compact_index(&self, index: &str) -> bool {
         self.db.compact_index(index).await
     }
 
-    /// See [Database::exists](crate::database::Database::exists)
+    /// See [`Database::exists`](crate::database::Database::exists)
     pub async fn exists(&self, id: &str) -> bool {
         self.db.exists(id).await
     }
 
-    /// See [Database::get](crate::database::Database::get)
+    /// See [`Database::get`](crate::database::Database::get)
     pub async fn get(&self, id: &str) -> CouchResult<T> {
         self.db.get(id).await
     }
 
-    /// See [Database::get_bulk](crate::database::Database::get_bulk)
+    /// See [`Database::get_bulk`](crate::database::Database::get_bulk)
     pub async fn get_bulk(&self, ids: Vec<DocumentId>) -> CouchResult<DocumentCollection<T>> {
         self.db.get_bulk(ids).await
     }
 
-    /// See [Database::bulk_docs](crate::database::Database::bulk_docs)
+    /// See [`Database::bulk_docs`](crate::database::Database::bulk_docs)
     pub async fn bulk_docs(&self, raw_docs: &mut [T]) -> CouchResult<Vec<DocumentCreatedResult>> {
         self.db.bulk_docs(raw_docs).await
     }
 
-    /// See [Database::get_bulk_params](crate::database::Database::get_bulk_params)
+    /// See [`Database::get_bulk_params`](crate::database::Database::get_bulk_params)
     pub async fn get_bulk_params(
         &self,
         ids: Vec<DocumentId>,
@@ -84,12 +86,12 @@ impl<T: TypedCouchDocument> Database<T> {
         self.db.get_bulk_params(ids, params).await
     }
 
-    /// See [Database::get_all](crate::database::Database::get_all)
+    /// See [`Database::get_all`](crate::database::Database::get_all)
     pub async fn get_all(&self) -> CouchResult<DocumentCollection<T>> {
         self.db.get_all().await
     }
 
-    /// See [Database::get_all_batched](crate::database::Database::get_all_batched)
+    /// See [`Database::get_all_batched`](crate::database::Database::get_all_batched)
     pub async fn get_all_batched(
         &self,
         tx: Sender<DocumentCollection<T>>,
@@ -99,7 +101,7 @@ impl<T: TypedCouchDocument> Database<T> {
         self.db.get_all_batched(tx, batch_size, max_results).await
     }
 
-    /// See [Database::find_batched](crate::database::Database::find_batched)
+    /// See [`Database::find_batched`](crate::database::Database::find_batched)
     pub async fn find_batched(
         &self,
         query: FindQuery,
@@ -110,7 +112,7 @@ impl<T: TypedCouchDocument> Database<T> {
         self.db.find_batched(query, tx, batch_size, max_results).await
     }
 
-    /// See [Database::query_many_all_docs](crate::database::Database::query_many_all_docs)
+    /// See [`Database::query_many_all_docs`](crate::database::Database::query_many_all_docs)
     pub async fn query_many_all_docs(
         &self,
         queries: QueriesParams,
@@ -118,7 +120,7 @@ impl<T: TypedCouchDocument> Database<T> {
         self.db.query_many_all_docs(queries).await
     }
 
-    /// See [Database::query_many](crate::database::Database::query_many)
+    /// See [`Database::query_many`](crate::database::Database::query_many)
     pub async fn query_many(
         &self,
         design_name: &str,
@@ -128,46 +130,42 @@ impl<T: TypedCouchDocument> Database<T> {
         self.db.query_many(design_name, view_name, queries).await
     }
 
-    /// See [Database::get_all_params](crate::database::Database::get_all_params)
+    /// See [`Database::get_all_params`](crate::database::Database::get_all_params)
     pub async fn get_all_params(&self, params: Option<QueryParams<DocumentId>>) -> CouchResult<DocumentCollection<T>> {
         self.db.get_all_params(params).await
     }
 
-    /// See [Database::find](crate::database::Database::find)
+    /// See [`Database::find`](crate::database::Database::find)
     pub async fn find(&self, query: &FindQuery) -> CouchResult<DocumentCollection<T>> {
         self.db.find(query).await
     }
 
-    /// See [Database::save](crate::database::Database::save)
+    /// See [`Database::save`](crate::database::Database::save)
     pub async fn save(&self, doc: &mut T) -> DocumentCreatedResult {
         self.db.save(doc).await
     }
 
-    /// See [Database::create](crate::database::Database::create)
+    /// See [`Database::create`](crate::database::Database::create)
     pub async fn create(&self, doc: &mut T) -> DocumentCreatedResult {
         self.db.create(doc).await
     }
 
-    /// See [Database::upsert](crate::database::Database::upsert)
+    /// See [`Database::upsert`](crate::database::Database::upsert)
     pub async fn upsert(&self, doc: &mut T) -> DocumentCreatedResult {
         self.db.upsert(doc).await
     }
 
-    /// See [Database::bulk_upsert](crate::database::Database::bulk_upsert)
+    /// See [`Database::bulk_upsert`](crate::database::Database::bulk_upsert)
     pub async fn bulk_upsert(&self, docs: &mut [T]) -> CouchResult<Vec<DocumentCreatedResult>> {
         self.db.bulk_upsert(docs).await
     }
 
-    /// See [Database::create_view](crate::database::Database::create_view)
-    pub async fn create_view<V: Into<serde_json::Value>>(
-        &self,
-        design_name: &str,
-        views: V,
-    ) -> CouchResult<DesignCreated> {
+    /// See [`Database::create_view`](crate::database::Database::create_view)
+    pub async fn create_view<V: Into<Value>>(&self, design_name: &str, views: V) -> CouchResult<DesignCreated> {
         self.db.create_view(design_name, views).await
     }
 
-    /// See [Database::query](crate::database::Database::query)
+    /// See [`Database::query`](crate::database::Database::query)
     pub async fn query<K: Serialize + DeserializeOwned + PartialEq + std::fmt::Debug + Clone, V: DeserializeOwned>(
         &self,
         design_name: &str,
@@ -177,7 +175,7 @@ impl<T: TypedCouchDocument> Database<T> {
         self.db.query(design_name, view_name, options).await
     }
 
-    /// See [Database::execute_update](crate::database::Database::execute_update)
+    /// See [`Database::execute_update`](crate::database::Database::execute_update)
     pub async fn execute_update(
         &self,
         design_id: &str,
@@ -188,12 +186,12 @@ impl<T: TypedCouchDocument> Database<T> {
         self.db.execute_update(design_id, name, document_id, body).await
     }
 
-    /// See [Database::remove](crate::database::Database::remove)
+    /// See [`Database::remove`](crate::database::Database::remove)
     pub async fn remove(&self, doc: &T) -> bool {
         self.db.remove(doc).await
     }
 
-    /// See [Database::insert_index](crate::database::Database::insert_index)
+    /// See [`Database::insert_index`](crate::database::Database::insert_index)
     pub async fn insert_index(
         &self,
         name: &str,
@@ -204,18 +202,19 @@ impl<T: TypedCouchDocument> Database<T> {
         self.db.insert_index(name, def, index_type, ddoc).await
     }
 
-    /// See [Database::read_indexes](crate::database::Database::read_indexes)
+    /// See [`Database::read_indexes`](crate::database::Database::read_indexes)
     pub async fn read_indexes(&self) -> CouchResult<DatabaseIndexList> {
         self.db.read_indexes().await
     }
 
-    /// See [Database::delete_index](crate::database::Database::delete_index)
+    /// See [`Database::delete_index`](crate::database::Database::delete_index)
     pub async fn delete_index(&self, ddoc: DocumentId, name: String) -> CouchResult<bool> {
         self.db.delete_index(ddoc, name).await
     }
 
-    /// See [Database::changes](crate::database::Database::changes)
-    pub fn changes(&self, last_seq: Option<serde_json::Value>) -> ChangesStream {
+    /// See [`Database::changes`](crate::database::Database::changes)
+    #[must_use]
+    pub fn changes(&self, last_seq: Option<Value>) -> ChangesStream {
         self.db.changes(last_seq)
     }
 }

--- a/couch_rs/src/types/find.rs
+++ b/couch_rs/src/types/find.rs
@@ -140,13 +140,13 @@ impl SelectAll {
     }
 }
 
-impl From<&SelectAll> for serde_json::Value {
+impl From<&SelectAll> for Value {
     fn from(s: &SelectAll) -> Self {
         serde_json::to_value(s).expect("can not convert into json")
     }
 }
 
-impl From<serde_json::Value> for SelectAll {
+impl From<Value> for SelectAll {
     fn from(value: Value) -> Self {
         serde_json::from_value(value).expect("json Value is not a valid Selector")
     }
@@ -268,19 +268,19 @@ impl FindQuery {
     }
 }
 
-impl From<FindQuery> for serde_json::Value {
+impl From<FindQuery> for Value {
     fn from(q: FindQuery) -> Self {
         serde_json::to_value(q).expect("can not convert into json")
     }
 }
 
-impl From<&FindQuery> for serde_json::Value {
+impl From<&FindQuery> for Value {
     fn from(q: &FindQuery) -> Self {
         serde_json::to_value(q).expect("can not convert into json")
     }
 }
 
-impl From<serde_json::Value> for FindQuery {
+impl From<Value> for FindQuery {
     fn from(value: Value) -> Self {
         serde_json::from_value(value).expect("json Value is not a valid FindQuery")
     }

--- a/couch_rs/src/types/view.rs
+++ b/couch_rs/src/types/view.rs
@@ -1,7 +1,7 @@
 use crate::document::TypedCouchDocument;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
+use std::{collections::HashMap, string::ToString};
 
 #[derive(Default, Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 #[serde(bound(deserialize = "T: TypedCouchDocument"))]
@@ -80,18 +80,18 @@ impl CouchFunc {
     pub fn new(map: &str, reduce: Option<&str>) -> Self {
         CouchFunc {
             map: map.to_string(),
-            reduce: reduce.map(std::string::ToString::to_string),
+            reduce: reduce.map(ToString::to_string),
         }
     }
 }
 
-impl From<CouchViews> for serde_json::Value {
+impl From<CouchViews> for Value {
     fn from(v: CouchViews) -> Self {
         serde_json::to_value(v).unwrap()
     }
 }
 
-impl From<CouchFunc> for serde_json::Value {
+impl From<CouchFunc> for Value {
     fn from(f: CouchFunc) -> Self {
         serde_json::to_value(f).unwrap()
     }
@@ -112,7 +112,7 @@ impl CouchUpdate {
     }
 }
 
-impl From<CouchUpdate> for serde_json::Value {
+impl From<CouchUpdate> for Value {
     fn from(u: CouchUpdate) -> Self {
         serde_json::to_value(u).unwrap()
     }


### PR DESCRIPTION
In case a database is used to store entries of the same type, this wrapper helps ensuring at compile time that the same database is not used with different types.