### PR TITLE
Make `database.remove(_)` use proper error types

### DIFF
--- a/couch_rs/src/database.rs
+++ b/couch_rs/src/database.rs
@@ -1,13 +1,19 @@
-use crate::{changes::ChangesStream, client::{is_accepted, is_ok, Client}, document::{DocumentCollection, TypedCouchDocument, ID_FIELD, REV_FIELD}, error, error::{CouchError, CouchResult, ErrorMessage}, types::{
-    design::DesignCreated,
-    document::{DocumentCreatedDetails, DocumentCreatedResponse, DocumentCreatedResult, DocumentId},
-    find::{FindQuery, FindResult},
-    index::{DatabaseIndexList, DeleteIndexResponse, IndexFields, IndexType},
-    query::{QueriesCollection, QueriesParams, QueryParams},
-    view::ViewCollection,
-}};
+use crate::{
+    changes::ChangesStream,
+    client::{is_accepted, is_ok, Client},
+    document::{DocumentCollection, TypedCouchDocument, ID_FIELD, REV_FIELD},
+    error::{CouchError, CouchResult, ErrorMessage},
+    types::{
+        design::DesignCreated,
+        document::{DocumentCreatedDetails, DocumentCreatedResponse, DocumentCreatedResult, DocumentId},
+        find::{FindQuery, FindResult},
+        index::{DatabaseIndexList, DeleteIndexResponse, IndexFields, IndexType},
+        query::{QueriesCollection, QueriesParams, QueryParams},
+        view::ViewCollection,
+    },
+};
 use futures_core::Future;
-use reqwest::{Error, Response, StatusCode};
+use reqwest::StatusCode;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::{from_value, json, to_string, Value};
 use std::{collections::HashMap, fmt::Debug, pin::Pin, sync::Arc};
@@ -1040,7 +1046,7 @@ impl Database {
             }
             Err(e) => {
                 let id: String = doc.get_id().into();
-                Err(error::CouchError::new_with_id(
+                Err(CouchError::new_with_id(
                     Some(id),
                     "Failed to delete document".to_string(),
                     e.status().unwrap_or(StatusCode::BAD_REQUEST))

--- a/couch_rs/src/lib.rs
+++ b/couch_rs/src/lib.rs
@@ -462,7 +462,7 @@ mod couch_rs_tests {
             assert!(!my_doc.get_rev().is_empty(), "Found empty _rev for document {my_doc:?}");
 
             let document: TestDocImplementing = db.get(&my_doc.my_id).await.expect("can not get doc");
-            assert!(db.remove(&document).await, "can not remove doc {document:?}");
+            assert!(db.remove(&document).await.is_ok(), "can not remove doc {document:?}");
 
             client
                 .destroy_db("create_read_remove_with_rev")
@@ -504,7 +504,7 @@ mod couch_rs_tests {
             assert!(!my_doc.get_rev().is_empty(), "Found empty _rev for document {my_doc:?}");
 
             let document: TestDocImplementing = db.get(UNIQUE_ID).await.expect("can not get doc");
-            assert!(db.remove(&document).await, "can not remove doc");
+            assert!(db.remove(&document).await.is_ok(), "can not remove doc");
 
             client
                 .destroy_db("should_keep_id_bulk_creating_a_typed_document_implementing")
@@ -645,7 +645,7 @@ mod couch_rs_tests {
             let dbname = "should_handle_a_document_plus";
             let (client, db, mut doc) = setup(dbname).await;
 
-            assert!(db.remove(&doc).await);
+            assert!(db.remove(&doc).await.is_ok());
             // make sure db is empty
             assert_eq!(db.get_all_raw().await.unwrap().rows.len(), 0);
 
@@ -662,7 +662,7 @@ mod couch_rs_tests {
             assert_eq!(db.get_all_raw().await.unwrap().rows.len(), 1);
 
             // delete it
-            assert!(db.remove(&created).await);
+            assert!(db.remove(&created).await.is_ok());
             // make sure db has no docs
             assert_eq!(db.get_all_raw().await.unwrap().rows.len(), 0);
 
@@ -672,7 +672,7 @@ mod couch_rs_tests {
         #[tokio::test]
         async fn should_remove_a_document() {
             let (client, db, doc) = setup("should_remove_a_document").await;
-            assert!(db.remove(&doc).await);
+            assert!(db.remove(&doc).await.is_ok());
 
             teardown(client, "should_remove_a_document").await;
         }
@@ -787,7 +787,7 @@ mod couch_rs_tests {
 
             let collection = db.get_bulk_raw(vec![id]).await.unwrap();
             assert_eq!(collection.rows.len(), 1);
-            assert!(db.remove(&doc).await);
+            assert!(db.remove(&doc).await.is_ok());
 
             teardown(client, "should_bulk_get_a_document").await;
         }
@@ -800,7 +800,7 @@ mod couch_rs_tests {
 
             let collection = db.get_bulk_raw(vec![id, invalid_id]).await.unwrap();
             assert_eq!(collection.rows.len(), 1);
-            assert!(db.remove(&doc).await);
+            assert!(db.remove(&doc).await.is_ok());
 
             teardown(client, "should_bulk_get_invalid_documents").await;
         }
@@ -814,7 +814,7 @@ mod couch_rs_tests {
 
             let collection = db.get_all_params_raw(Some(params)).await.unwrap();
             assert_eq!(collection.rows.len(), 1);
-            assert!(db.remove(&doc).await);
+            assert!(db.remove(&doc).await.is_ok());
 
             teardown(client, "should_get_all_documents_with_keys").await;
         }
@@ -892,8 +892,8 @@ mod couch_rs_tests {
                 0
             );
 
-            assert!(db.remove(&second_doc).await);
-            assert!(db.remove(&doc).await);
+            assert!(db.remove(&second_doc).await.is_ok());
+            assert!(db.remove(&doc).await.is_ok());
 
             teardown(client, db_name).await;
         }
@@ -968,8 +968,8 @@ mod couch_rs_tests {
                 0
             );
 
-            assert!(db.remove(&ndoc).await);
-            assert!(db.remove(&doc).await);
+            assert!(db.remove(&ndoc).await.is_ok());
+            assert!(db.remove(&doc).await.is_ok());
 
             teardown(client, db_name).await;
         }
@@ -1051,8 +1051,8 @@ mod couch_rs_tests {
                 1
             );
 
-            assert!(db.remove(&ndoc).await);
-            assert!(db.remove(&doc).await);
+            assert!(db.remove(&ndoc).await.is_ok());
+            assert!(db.remove(&doc).await.is_ok());
 
             teardown(client, dbname).await;
         }
@@ -1088,7 +1088,7 @@ mod couch_rs_tests {
             assert!(collections.get(2).unwrap().rows.first().unwrap().doc.is_none());
 
             for doc in docs {
-                assert!(db.remove(&doc).await);
+                assert!(db.remove(&doc).await.is_ok());
             }
 
             teardown(client, dbname).await;

--- a/couch_rs/src/typed.rs
+++ b/couch_rs/src/typed.rs
@@ -190,7 +190,7 @@ impl<T: TypedCouchDocument> Database<T> {
     }
 
     /// See [`Database::remove`](crate::database::Database::remove)
-    pub async fn remove(&self, doc: &T) -> bool {
+    pub async fn remove(&self, doc: &T) -> CouchResult<()> {
         self.db.remove(doc).await
     }
 


### PR DESCRIPTION
**_This is a breaking change for the `remove` impl, it used to return a boolean and now returns a result._**

This PR is more of an idea than something to merge, but I don't think using a `bool` to represent success makes sense if there are multiple failure modes.

I honestly don't know if this is worth changing the API for, but I think this is a better way to do it.

I'm gonna leave this as a draft because I noticed the contributing guidelines too late and I'm too lazy to learn git flow for a couple lines